### PR TITLE
Work around Object.create(CustomEvent) issue

### DIFF
--- a/src/dom-listener.coffee
+++ b/src/dom-listener.coffee
@@ -55,7 +55,7 @@ class DOMListener
     propagationStopped = false
     immediatePropagationStopped = false
 
-    syntheticEvent = Object.create event,
+    syntheticEvent = Object.create {},
       eventPhase: value: Event.BUBBLING_PHASE
       currentTarget: get: -> currentTarget
       stopPropagation: value: ->
@@ -65,6 +65,10 @@ class DOMListener
         propagationStopped = true
         immediatePropagationStopped = true
         event.stopImmediatePropagation()
+
+    # NOTE: In Chrome 43, Object.create doesn't work well with CustomEvent
+    for key in Object.keys(event)
+      syntheticEvent[key] = event[key]
 
     loop
       inlineListeners = @inlineListenersByEventName[event.type]?.get(currentTarget)


### PR DESCRIPTION
This fixes the issue I was seeing in #1 - apparently Chrome 43 has issues using Object.create with CustomEvent.
