### PR TITLE
fixes #4, by simply filtering out webkitMovement's

### DIFF
--- a/src/dom-listener.coffee
+++ b/src/dom-listener.coffee
@@ -75,8 +75,10 @@ class DOMListener
       defaultPrevented: get: -> defaultPrevented
     }
 
-    for key, value of event
-      descriptor[key] ?= {value}
+    for key of event
+      if (key != 'webkitMovementX' && key != 'webkitMovementY')
+        value = event[key]
+        descriptor[key] ?= {value}
 
     syntheticEvent = Object.create(event.constructor.prototype, descriptor)
 


### PR DESCRIPTION
Just like https://github.com/videojs/video.js/pull/2558/commits/9a17c17e34bedc0c882f0ba60d3a60bf7c8c9f98

The warning is generated by accessing `event['webkitMovementX']` so the coffee key/value syntax sugaring needed to go.
